### PR TITLE
Remove not used second parameter from message

### DIFF
--- a/language/de/postlove.php
+++ b/language/de/postlove.php
@@ -23,7 +23,7 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_USER_LIKES'	=> 'User gefallen',
 	'POSTLOVE_USER_LIKED'	=> 'User gefällt',
 
-	'NOTIFICATION_POSTLOVE_ADD'	=> '%1$s <b>gefällt</b> dein Beitrag "%2$s"',
+	'NOTIFICATION_POSTLOVE_ADD'	=> '%1$s <b>gefällt</b> dein Beitrag:',
 	'NOTIFICATION_TYPE_POST_LOVE'	=> 'Beitrag gefällt.',
 
 	// Ver 1.1


### PR DESCRIPTION
Otherwise a PHP warning is generated
[phpBB Debug] PHP Warning: in file [ROOT]/phpbb/language/language.php on line 313: vsprintf(): Too few arguments