### PR TITLE
Add ACP button to import data from Thanks for Posts extension

### DIFF
--- a/acp/acp_postlove_module.php
+++ b/acp/acp_postlove_module.php
@@ -126,7 +126,8 @@ class acp_postlove_module
 
 		// Is there and Thanks for Posts data to import?
 		$thanks_to_convert = 0;
-		$db_tools = new \phpbb\db\tools($db);
+		/* @var $db_tools \phpbb\db\tools\tools_interface */
+		$db_tools = $phpbb_container->get('dbal.tools');
 		if ($db_tools->sql_table_exists($table_prefix . 'thanks'))
 		{
 			$sql = 'SELECT COUNT(t.thanks_time) as item_count

--- a/adm/style/acp_postlove.html
+++ b/adm/style/acp_postlove.html
@@ -91,6 +91,24 @@
 					</dd>
 				</dl>
 			</fieldset>
+			<fieldset>
+				<dl>
+					<!-- IF THANKS_TO_CONVERT -->
+					<dt>
+						<label>{THANKS_TO_CONVERT} {L_POSTLOVE_IMPORT_THANKS}</label><br />
+						<span>{L_POSTLOVE_IMPORT_THANKS_EXPLAIN}</span>
+					</dt>
+					<dd>
+						<input class="button1" type="submit" id="import" name="import" value="{L_IMPORT}" />
+					</dd>
+					<!-- ELSE -->
+					<dt>
+						<label>{L_POSTLOVE_IMPORT_THANKS}</label><br />
+						<span>{L_POSTLOVE_IMPORT_NO_THANKS_EXPLAIN}</span>
+					</dt>
+					<!-- ENDIF -->
+				</dl>
+			</fieldset>
 	</form>
 <!-- INCLUDE overall_footer.html -->
 

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"type": "phpbb-extension",
 	"description": "Adds ability to favourite/like/thank a post.",
 	"homepage": "http://lab.anavaro.com/forum/viewforum.php?f=5",
-	"version": "2.0.0-b2",
-	"time": "2019-12-06",
+	"version": "2.0.0-b3",
+	"time": "2019-12-28",
 	"license": "GPL-2.0-only",
 	"authors": [
 		{

--- a/language/bg/info_acp_postlove.php
+++ b/language/bg/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'	=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/cs/info_acp_postlove.php
+++ b/language/cs/info_acp_postlove.php
@@ -48,4 +48,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'	=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=>'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/de/info_acp_postlove.php
+++ b/language/de/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=>'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/en/info_acp_postlove.php
+++ b/language/en/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'					=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'				=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'		=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/es/info_acp_postlove.php
+++ b/language/es/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/fr/info_acp_postlove.php
+++ b/language/fr/info_acp_postlove.php
@@ -69,4 +69,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/nl/info_acp_postlove.php
+++ b/language/nl/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/pl/info_acp_postlove.php
+++ b/language/pl/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'Ile wyświetlać na stronie głównej',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Wyświetlać liczbę polubień na przycisku posta?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'Status liczby polubień i link akcji mogą się wyświetlać w formie przycisku nad postem, bądź pod postem zgodnie ze starym formatem.',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/pt_br/info_acp_postlove.php
+++ b/language/pt_br/info_acp_postlove.php
@@ -50,4 +50,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/language/tr/info_acp_postlove.php
+++ b/language/tr/info_acp_postlove.php
@@ -46,4 +46,9 @@ $lang = array_merge($lang, array(
 	'POSTLOVE_INDEX'		=> 'How many to show on Index page',
 	'POSTLOVE_SHOW_BUTTON'	=> 'Show the Post like count in a Post Button?',
 	'POSTLOVE_SHOW_BUTTON_EXPLAIN'	=> 'The Post like count status and action link may be shown as a Post Button at the top of the post or in the old format at the bottom of the post',
+
+	'POSTLOVE_IMPORT_THANKS'			=> 'Thanks records able to be imported',
+	'POSTLOVE_IMPORT_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension, this operation does not change the data of the other extension',
+	'POSTLOVE_IMPORT_NO_THANKS_EXPLAIN'	=> 'Thanks records can be imported from the Thanks for Posts extension but no suitable records found',
+	'IMPORT'							=> 'Import',
 ));

--- a/migrations/release_1_2_0_create_cpf.php
+++ b/migrations/release_1_2_0_create_cpf.php
@@ -27,7 +27,7 @@ class release_1_2_0_create_cpf extends \phpbb\db\migration\profilefield_base_mig
 		);
 	}
 	protected $profilefield_name = 'postlove_hide';
-	protected $profilefield_database_type = array('UINT:2', 1);
+	protected $profilefield_database_type = array('UINT:2');
 	protected $profilefield_data = array(
 		'field_name'            => 'postlove_hide',
 		'field_type'			=> 'profilefields.type.bool',


### PR DESCRIPTION
One of the forums I help to administer previously had Thanks for Posts extension installed, and I wanted to upgrade to Postlove, so I wrote some code to import the data.

It has been tested on a forum that had 21000 thanks records.